### PR TITLE
As of 5.19.2 or so, lex_stuff may have spaces

### DIFF
--- a/signatures.xs
+++ b/signatures.xs
@@ -170,6 +170,11 @@ handle_proto (pTHX_ OP *op, void *user_data) {
 			continue;
 		}
 
+		if (isSPACE (tmp2[0])) {
+			tmp2++;
+			continue;
+		}
+
 		if (*tmp2 != *s) {
 			return op;
 		}

--- a/signatures.xs
+++ b/signatures.xs
@@ -216,8 +216,9 @@ handle_proto (pTHX_ OP *op, void *user_data) {
 						attr_start++;
 					}
 
-					ret = op;
-					sv_setpv (op_sv, tmp2);
+					ret = newSVOP (OP_CONST, 0, newSVpvn (tmp2, strlen (tmp2)));
+					op_free (op);
+					op = ret;
 				}
 			}
 			else if (strEQ (tmpbuf, "proto")) {


### PR DESCRIPTION
so those need to be skipped as well
